### PR TITLE
5 module fix

### DIFF
--- a/main/dist/package.json
+++ b/main/dist/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/enepomnyaschih/byte-base64.git"
   },
   "main": "lib.js",
+  "browser": "lib.js",
   "module": "lib.es6.js",
   "typings": "lib.d.ts"
 }


### PR DESCRIPTION
I'm not familiar with parcel but there seems to be something strange with it.

From what I can see in IE11 dev tools, it's trying to parse typescript code, so parcel does not send the right asset ??

Anyway, all I had to do to fix it is to modify package.json to add an entry for 'browser', I'm not sure why it does not work without it, because it should IMO.